### PR TITLE
Fix dimension mismatch when using nerf_type==latent_tune

### DIFF
--- a/src/latent_nerf/models/network_grid.py
+++ b/src/latent_nerf/models/network_grid.py
@@ -21,7 +21,7 @@ class NeRFNetwork(NeRFRenderer):
 
         self.num_layers = num_layers
         self.hidden_dim = hidden_dim
-        additional_dim_size = 1 if self.latent_mode else 0
+        additional_dim_size = 1 if (self.latent_mode or cfg.nerf_type == NeRFType.latent_tune) else 0
 
         self.encoder, self.in_dim = get_encoder('tiledgrid', input_dim=3, desired_resolution=2048 * self.bound)
 


### PR DESCRIPTION
In original code the additional_dim_size = 0 for latent_tune style, meaning MLPs have channels=3, while the decoder_layer has input channels = 4